### PR TITLE
Allow transforming without an alias

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -122,6 +122,11 @@ function getImports(filePath, code, aliasOptions) {
 
       if (absolutePathFromRoot.indexOf(aliasRelativeToRoot) === 0) {
         var aliasedPath = absolutePathFromRoot.replace(aliasRelativeToRoot, alias);
+
+        if (alias === '' && aliasedPath.startsWith('/')) {
+          aliasedPath = aliasedPath.slice(1);
+        }
+
         sourceNode.value = aliasedPath; //remove leading and trailing comments from the node
 
         node.leadingComments = undefined;

--- a/src/util.js
+++ b/src/util.js
@@ -126,7 +126,11 @@ function getImports(filePath: string, code: string, aliasOptions: aliasOptions) 
     if (relativePath && !isNodeModule(relativePath)) {
       const absolutePathFromRoot = path.join(pathDirname(filePath), relativePath);
       if (absolutePathFromRoot.indexOf(aliasRelativeToRoot) === 0) {
-        const aliasedPath = absolutePathFromRoot.replace(aliasRelativeToRoot, alias);
+        let aliasedPath = absolutePathFromRoot.replace(aliasRelativeToRoot, alias);
+        if (alias === '' && aliasedPath.startsWith('/')) {
+          aliasedPath = aliasedPath.slice(1);
+        }
+
         sourceNode.value = aliasedPath;
 
         //remove leading and trailing comments from the node

--- a/test/transform.spec.js
+++ b/test/transform.spec.js
@@ -141,4 +141,21 @@ describe('Test transformation', () => {
 
     test(code, expected, filePath, aliasInfo);
   });
+
+  it('should alias root directories', () => {
+    const  aliasInfo = {
+      alias: '',
+      aliasRelativeToRoot: 'src'
+    }
+
+    const code  = `
+      import common from '../../utils/common';
+    `;
+
+    const expected = `
+      import common from 'utils/common';
+    `;
+
+    test(code, expected, defaultFilePath, aliasInfo);
+  });
 });


### PR DESCRIPTION
This change allows specifying an empty alias so this tool can be used to convert from relative paths to relative to root.